### PR TITLE
US969005: Use latest opensuse base image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,8 +125,7 @@
                     <imageManagement>
                         <image>
                             <repository>${dockerHubPublic}/cafapi/opensuse-base</repository>
-                            <tag>4.1.2</tag>
-                            <digest>sha256:e9af8f1bf1decac9a35227e33ad9717f3af0955e34da0556b1a342b765c8ce10</digest>
+                            <tag>4.2.0-US969005-SNAPSHOT</tag>
                         </image>
                         <image>
                             <repository>${dockerHubPublic}/library/oraclelinux</repository>

--- a/pom.xml
+++ b/pom.xml
@@ -124,8 +124,9 @@
                 <configuration>
                     <imageManagement>
                         <image>
-                            <repository>${dockerHubPublic}/cafapi/opensuse-base</repository>
-                            <tag>4.2.0-US969005-SNAPSHOT</tag>
+                            <targetRepository>cafapi/opensuse-base</targetRepository>
+                            <repository>${dockerHubPublic}/cafapi/prereleases</repository>
+                            <tag>opensuse-base-4.2.0-US969005-SNAPSHOT</tag>
                         </image>
                         <image>
                             <repository>${dockerHubPublic}/library/oraclelinux</repository>

--- a/release-notes-1.1.0.md
+++ b/release-notes-1.1.0.md
@@ -4,5 +4,12 @@
 ${version-number}
 
 #### New Features
+- US969005: Add support for converting file-based secrets to properties.  
+  Example: For each environment variable ending in the `_FILE` suffix:  
+  `ABC_PASSWORD_FILE=/var/somefile.txt`  
+  The contents of `/var/somefile.txt` (e.g., `mypassword`) will be read and then written to `/maven/secret-props.txt` as:  
+  `-DCAF.ABC_PASSWORD=mypassword`  
+  Note that the prefix `CAF.` is added to the property name.  
+  This functionality is enabled by setting the environment variable `CONVERT_FILE_BASED_SECRETS_TO_PROPS=true`.
 
 #### Known Issues


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=969005